### PR TITLE
修复Arm侧卸载驱动时的段错误，修改测试方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 ## Arm侧驱动
 
+1. 仅进行BAR0映射表的配置
 ``` bash
 make arm
 ```
 
+2. 进行Arm2Host的性能测试
+``` bash
+make armtest
+```
+
 ## Host侧驱动
 
+1. 仅进行DMA内存的分配与设备的使能
 ``` bash
 make host
+```
+
+2. 打开debug打印线程
+``` bash
+make hostdebug
 ```

--- a/mem_dma_driver/mem_dma.c
+++ b/mem_dma_driver/mem_dma.c
@@ -38,25 +38,26 @@
 #define DMA_CH_SIZE_34 (128 * 1024 * 1024) // 128 MB
 #define DMA_CH_SIZE_35 (256 * 1024 * 1024) // 256 MB
 
-#define BAR4_TEST_SIZE (4 * 1024) // 4KB
+// #define BAR4_TEST
+#define BAR4_TEST_SIZE (4 * 1024)
 #define BAR4_TEST_ITERATION (10000)
 #define BAR4_LATENCY_ITERATION (10000)
 #define BAR4_TEST_OFFSET (0x0)
 
 /**
  * struct bar4_perf_stats - BAR4性能统计数据
- * @read_bandwidth_mbps: 读取带宽 (MB/s)
- * @write_bandwidth_mbps: 写入带宽 (MB/s)
- * @read_latency_ns: 平均读取延迟 (纳秒)
- * @write_latency_ns: 平均写入延迟 (纳秒)
- * @min_read_latency_ns: 最小读取延迟 (纳秒)
- * @max_read_latency_ns: 最大读取延迟 (纳秒)
- * @min_write_latency_ns: 最小写入延迟 (纳秒)
- * @max_write_latency_ns: 最大写入延迟 (纳秒)
+ * @read_bandwidth_gbps: 读取带宽 (GB/s)
+ * @write_bandwidth_gbps: 写入带宽 (GB/s)
+ * @read_latency_ns: 平均读取延迟 (ns)
+ * @write_latency_ns: 平均写入延迟 (ns)
+ * @min_read_latency_ns: 最小读取延迟 (ns)
+ * @max_read_latency_ns: 最大读取延迟 (ns)
+ * @min_write_latency_ns: 最小写入延迟 (ns)
+ * @max_write_latency_ns: 最大写入延迟 (ns)
  */
 typedef struct {
-  u64 read_bandwidth_mbps;
-  u64 write_bandwidth_mbps;
+  u64 read_bandwidth_gbps;
+  u64 write_bandwidth_gbps;
   u64 read_latency_ns;
   u64 write_latency_ns;
   u64 min_read_latency_ns;
@@ -138,10 +139,11 @@ static u64 bar4_performance_test(xilinx_dma_dev_t *dev_priv, char rw, char type,
                                  u64 *min_latency, u64 *max_latency) {
   ktime_t start_time, end_time;
   u64 total_bytes = (u64)BAR4_TEST_SIZE * BAR4_TEST_ITERATION;
-  u64 duration_ns, bandwidth_mbps, total_latency = 0, latency_ns,
+  u64 duration_ns, bandwidth_gbps, total_latency = 0, latency_ns,
                                    min_lat = U64_MAX, max_lat = 0, avg_latency;
   int i, j;
   void __iomem *bar4_ptr;
+  u32 *test_data;
   volatile u32 dummy_read;
 
   if (!dev_priv->bar4_virt_addr) {
@@ -166,29 +168,36 @@ static u64 bar4_performance_test(xilinx_dma_dev_t *dev_priv, char rw, char type,
   // BAR4 start test offset
   bar4_ptr = dev_priv->bar4_virt_addr + BAR4_TEST_OFFSET;
 
+  test_data = kmalloc(BAR4_TEST_SIZE, GFP_KERNEL);
+  if (!test_data) {
+    pr_err("%s: Failed to allocate test data buffer\n", DRIVER_NAME);
+    return 0;
+  }
+
+  // padding
+  for (i = 0; i < BAR4_TEST_SIZE / sizeof(u32); i++) {
+    test_data[i] = 0x12345678 + i;
+  }
+
   // Bandwidth Test
   if (type == 'b') {
-    // pre
-    for (i = 0; i < 100; i++) {
-      for (j = 0; j < BAR4_TEST_SIZE / sizeof(u32); j++) {
-        if (rw == 'w') {
-          iowrite32(0x12345678, bar4_ptr + j * sizeof(u32));
-        } else if (rw == 'r') {
-          dummy_read = ioread32(bar4_ptr + j * sizeof(u32));
-        }
+    // prepare
+    for (i = 0; i < 10; i++) {
+      if (rw == 'w') {
+        memcpy_toio(bar4_ptr, test_data, BAR4_TEST_SIZE);
+      } else if (rw == 'r') {
+        memcpy_fromio(test_data, bar4_ptr, BAR4_TEST_SIZE);
       }
     }
 
     start_time = ktime_get();
 
-    // Bandwidth test
+    // Bandwidth
     for (i = 0; i < BAR4_TEST_ITERATION; i++) {
-      for (j = 0; j < BAR4_TEST_SIZE / sizeof(u32); j++) {
-        if (rw == 'w') {
-          iowrite32(0xAAAAAAAA + i + j, bar4_ptr + j * sizeof(u32));
-        } else if (rw == 'r') {
-          dummy_read = ioread32(bar4_ptr + j * sizeof(u32));
-        }
+      if (rw == 'w') {
+        memcpy_toio(bar4_ptr, test_data, BAR4_TEST_SIZE);
+      } else if (rw == 'r') {
+        memcpy_fromio(test_data, bar4_ptr, BAR4_TEST_SIZE);
       }
     }
 
@@ -198,23 +207,22 @@ static u64 bar4_performance_test(xilinx_dma_dev_t *dev_priv, char rw, char type,
     if (duration_ns == 0) {
       pr_warn("%s: %s test duration too short to measure\n", DRIVER_NAME,
               (rw == 'w') ? "Write" : "Read");
+      kfree(test_data);
       return 0;
     }
 
-    bandwidth_mbps = (total_bytes * 1000) / (duration_ns / 1000000); // MB/s
+    bandwidth_gbps = (total_bytes) / (duration_ns / 1000000); // GB/s
 
-    if (rw == 'r') {
-      (void)dummy_read;
-    }
+    pr_info("%s: BAR4 %s bandwidth test: %llu GB/s\n", DRIVER_NAME,
+            (rw == 'w') ? "Write" : "Read", bandwidth_gbps);
 
-    pr_info("%s: BAR4 %s bandwidth test: %llu MB/s\n", DRIVER_NAME,
-            (rw == 'w') ? "Write" : "Read", bandwidth_mbps);
-
-    return bandwidth_mbps;
+    kfree(test_data);
+    return bandwidth_gbps;
   }
   // Latency Test
   else if (type == 'l') {
-    for (i = 0; i < 1000; i++) {
+    // 预热
+    for (i = 0; i < 100; i++) {
       if (rw == 'w')
         iowrite32(0x12345678, bar4_ptr);
       else
@@ -245,16 +253,19 @@ static u64 bar4_performance_test(xilinx_dma_dev_t *dev_priv, char rw, char type,
     *max_latency = max_lat;
 
     avg_latency = total_latency / BAR4_LATENCY_ITERATION;
+    // printk("[DEBUG]: total_latency = %llu", total_latency);
 
     pr_info("%s: BAR4 %s latency - Avg: %llu ns, Min: %llu ns, Max: %llu ns\n",
             DRIVER_NAME, (rw == 'w') ? "Write" : "Read", avg_latency, min_lat,
             max_lat);
 
+    kfree(test_data);
     return avg_latency;
   }
   // Invalid Test
   else {
     pr_err("%s: Invalid test type '%c'\n", DRIVER_NAME, type);
+    kfree(test_data);
     return 0;
   }
 }
@@ -267,22 +278,22 @@ static void run_bar4_tests(xilinx_dma_dev_t *dev_priv) {
     return;
   }
 
-  dev_priv->perf_stats.write_bandwidth_mbps =
+  dev_priv->perf_stats.write_bandwidth_gbps =
       bar4_performance_test(dev_priv, 'w', 'b', NULL, NULL);
-  dev_priv->perf_stats.read_bandwidth_mbps =
+  dev_priv->perf_stats.read_bandwidth_gbps =
       bar4_performance_test(dev_priv, 'r', 'b', NULL, NULL);
   dev_priv->perf_stats.write_latency_ns = bar4_performance_test(
       dev_priv, 'w', 'l', &dev_priv->perf_stats.min_write_latency_ns,
       &dev_priv->perf_stats.max_write_latency_ns);
-  dev_priv->perf_stats.write_latency_ns = bar4_performance_test(
+  dev_priv->perf_stats.read_latency_ns = bar4_performance_test(
       dev_priv, 'r', 'l', &dev_priv->perf_stats.min_read_latency_ns,
       &dev_priv->perf_stats.max_read_latency_ns);
   pr_info("%s: BAR4 Performance Test Summary:\n", DRIVER_NAME);
   pr_info("%s: ================================\n", DRIVER_NAME);
   pr_info("%s: Write Bandwidth: %llu MB/s\n", DRIVER_NAME,
-          dev_priv->perf_stats.write_bandwidth_mbps);
+          dev_priv->perf_stats.write_bandwidth_gbps);
   pr_info("%s: Read Bandwidth:  %llu MB/s\n", DRIVER_NAME,
-          dev_priv->perf_stats.read_bandwidth_mbps);
+          dev_priv->perf_stats.read_bandwidth_gbps);
   pr_info("%s: Write Latency:   %llu ns (Min: %llu, Max: %llu)\n", DRIVER_NAME,
           dev_priv->perf_stats.write_latency_ns,
           dev_priv->perf_stats.min_write_latency_ns,
@@ -351,17 +362,6 @@ static int mem_dma_probe(struct pci_dev *pdev, const struct pci_device_id *id) {
     goto err_release_regions;
   }
 #ifdef BAR4_TEST
-  // alloc test buffer
-  dev_priv->test_buffer = kzalloc(BAR4_TEST_SIZE, GFP_KERNEL);
-  if (!dev_priv->test_buffer) {
-    pr_err("%s: Failed to allocate test buffer\n", DRIVER_NAME);
-    err = -ENOMEM;
-    goto err_free_priv;
-  }
-  // init
-  for (i = 0; i < BAR4_TEST_SIZE / sizeof(u32); i++) {
-    ((u32 *)dev_priv->test_buffer)[i] = 0x12345678 + i;
-  }
   // BAR4 mapping
   dev_priv->bar4_size = pci_resource_len(pdev, 4);
   if (dev_priv->bar4_size > 0) {
@@ -437,6 +437,7 @@ static int mem_dma_probe(struct pci_dev *pdev, const struct pci_device_id *id) {
 #ifdef BAR4_TEST
   if (dev_priv->bar4_virt_addr) {
     run_bar4_tests(dev_priv);
+    kfree(dev_priv->test_buffer);
   }
 #endif
 
@@ -481,9 +482,23 @@ static void mem_dma_remove(struct pci_dev *pdev) {
   }
 
   if (dev_priv->dma_virt_addr) {
+#ifdef ARM_BUILD
+    dma_free_coherent(&pdev->dev, DMA_BUFFER_SIZE_ARM, dev_priv->dma_virt_addr,
+                      dev_priv->dma_handle);
+#else
     dma_free_coherent(&pdev->dev, DMA_BUFFER_SIZE, dev_priv->dma_virt_addr,
                       dev_priv->dma_handle);
+#endif
   }
+
+  if (dev_priv->bar0_virt_addr) {
+    pci_iounmap(pdev, dev_priv->bar0_virt_addr);
+  }
+#ifdef BAR4_TEST
+  if (dev_priv->bar4_virt_addr) {
+    pci_iounmap(pdev, dev_priv->bar4_virt_addr);
+  }
+#endif
 
   pci_clear_master(pdev);
 


### PR DESCRIPTION
使用memcpy_fromio/toio替代带宽测试中的ioread/write